### PR TITLE
chore(fern): update config and bump fern version to 5.49.2

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -8,6 +8,12 @@ title: NVIDIA AITune Documentation
 instances:
   - url: aitune.docs.buildwithfern.com
     custom-domain: docs.nvidia.com/aitune
+    multi-source: true
+
+metadata:
+  canonical-host: "docs.nvidia.com/aitune"
+
+global-theme: nvidia
 
 agents:
   page-directive: "For clean Markdown content of this page, append .md to this URL."
@@ -23,9 +29,9 @@ products:
 
 redirects:
   - source: "/aitune/index.html"
-    destination: "/aitune/"
+    destination: "/aitune"
   - source: "/aitune/dev/index.html"
-    destination: "/aitune/dev/"
+    destination: "/aitune/dev"
 
 navbar-links:
   - type: github
@@ -40,24 +46,6 @@ layout:
   content-width: 812px
   tabs-placement: header
   hide-feedback: true
-
-metadata:
-  canonical-host: "docs.nvidia.com/aitune"
-
-experimental:
-  mdx-components:
-    - ./components
-  basepath-aware: true
-
-libraries:
-  aitune:
-    input:
-      git: https://github.com/ai-dynamo/aitune
-      subpath: aitune
-    output:
-      path: ../docs/api
-    lang: python
-
 
 colors:
   accentPrimary:
@@ -84,10 +72,23 @@ logo:
   dark: ../docs/assets/NVIDIA_dark.svg
   light: ../docs/assets/NVIDIA_light.svg
   height: 20
-  href: /
+  href: /aitune
   right-text: Documentation
 
 favicon: ../docs/assets/NVIDIA_symbol.svg
 
 css:
   - ./main.css
+
+experimental:
+  mdx-components:
+    - ./components
+
+libraries:
+  aitune:
+    input:
+      git: https://github.com/ai-dynamo/aitune
+      subpath: aitune
+    output:
+      path: ../docs/api
+    lang: python

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.20.1"
+  "version": "5.49.2"
 }


### PR DESCRIPTION
## Summary

- Bumps Fern CLI version from `5.20.1` to `5.49.2`
- Adds `multi-source: true` and `global-theme: nvidia` to the docs instance config
- Moves `metadata` block above `agents` for cleaner ordering
- Removes trailing slashes from redirect destinations
- Fixes logo `href` from `/` to `/aitune`
- Removes `experimental.basepath-aware` (no longer needed)
- Relocates `experimental.mdx-components` and `libraries` sections to end of file

## Test plan

- [ ] Verify Fern build succeeds with new version (`fern generate --docs`)
- [ ] Confirm redirects resolve correctly without trailing slashes
- [ ] Check docs render at `docs.nvidia.com/aitune` with NVIDIA global theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)